### PR TITLE
fix indentation: copy leading spaces from current line

### DIFF
--- a/lua/debugprint/init.lua
+++ b/lua/debugprint/init.lua
@@ -55,16 +55,6 @@ local filetype_configured = function()
     end
 end
 
-local indent_line = function(current_line)
-    local pos = vim.api.nvim_win_get_cursor(0)
-    -- There's probably a better way to do this indent, but I don't know what it is
-    vim.cmd(current_line + 1 .. "normal! ==")
-
-    if not global_opts.move_to_debugline then
-        vim.api.nvim_win_set_cursor(0, pos)
-    end
-end
-
 M.NOOP = function() end
 
 local set_callback = function(func_name)
@@ -74,7 +64,7 @@ local set_callback = function(func_name)
 end
 
 local debugprint_addline = function(opts)
-    local current_line = vim.api.nvim_win_get_cursor(0)[1]
+    local current_line_nr = vim.api.nvim_win_get_cursor(0)[1]
     local filetype =
         vim.api.nvim_get_option_value("filetype", { scope = "local" })
     local fixes = global_opts.filetypes[filetype]
@@ -96,10 +86,13 @@ local debugprint_addline = function(opts)
         line_to_insert_content = fixes.left .. debuginfo() .. fixes.right
     end
 
+    local current_line = vim.api.nvim_get_current_line()
+    local leading_space = current_line:match('(%s+)') or ''
+
     if opts.above then
-        line_to_insert_linenr = current_line - 1
+        line_to_insert_linenr = current_line_nr - 1
     else
-        line_to_insert_linenr = current_line
+        line_to_insert_linenr = current_line_nr
     end
 
     vim.api.nvim_buf_set_lines(
@@ -107,10 +100,8 @@ local debugprint_addline = function(opts)
         line_to_insert_linenr,
         line_to_insert_linenr,
         true,
-        { line_to_insert_content }
+        { leading_space .. line_to_insert_content }
     )
-
-    indent_line(line_to_insert_linenr)
 end
 
 local cache_request = nil

--- a/lua/debugprint/init.lua
+++ b/lua/debugprint/init.lua
@@ -63,6 +63,16 @@ local set_callback = function(func_name)
     vim.go.operatorfunc = func_name
 end
 
+local indent_line = function(current_line)
+    local pos = vim.api.nvim_win_get_cursor(0)
+    -- There's probably a better way to do this indent, but I don't know what it is
+    vim.cmd(current_line + 1 .. "normal! ==")
+
+    if not global_opts.move_to_debugline then
+        vim.api.nvim_win_set_cursor(0, pos)
+    end
+end
+
 local debugprint_addline = function(opts)
     local current_line_nr = vim.api.nvim_win_get_cursor(0)[1]
     local filetype =
@@ -102,6 +112,7 @@ local debugprint_addline = function(opts)
         true,
         { leading_space .. line_to_insert_content }
     )
+    indent_line(line_to_insert_linenr)
 end
 
 local cache_request = nil


### PR DESCRIPTION
The current indent logic does not alway work, especially in python.
This PR fixes the issue by simply copying the leading spaces from the current line.
