### PR TITLE
Ignore regexp patterns in print_tag when deleting lines

### DIFF
--- a/lua/debugprint/init.lua
+++ b/lua/debugprint/init.lua
@@ -307,7 +307,7 @@ M.deleteprints = function(opts)
     local delete_adjust = 0
 
     for count, line in ipairs(lines_to_consider) do
-        if string.find(line, global_opts.print_tag) ~= nil then
+        if string.find(line, global_opts.print_tag, 1, true) ~= nil then
             local line_to_delete = count
                 - 1
                 - delete_adjust


### PR DESCRIPTION
Currently, if there is a regexp pattern within the print_tag, it gets evaluated when looking for lines to delete. 

I wanted to color the tag to make it easier to see in the console output (for example using `print_tag = "\\033[33mDEBUG\\033[0m"` to make it yellow), this didn't work. 

With this change, the plain_text (see https://www.lua.org/manual/5.1/manual.html#pdf-string.find) is used and regexp is not evaluated. The third parameter (init) is set to 1, the default.