### PR TITLE
refactor: add types for keymaps

### DIFF
--- a/lua/debugprint/init.lua
+++ b/lua/debugprint/init.lua
@@ -213,8 +213,7 @@ M.debugprint_regular = function(opts)
     return "g@l"
 end
 
----@param opts DebugprintFunctionOptions
----@return nil
+---@param opts? DebugprintFunctionOptions
 M.debugprint = function(opts)
     local func_opts =
         require("debugprint.options").get_and_validate_function_opts(opts)

--- a/lua/debugprint/init.lua
+++ b/lua/debugprint/init.lua
@@ -214,6 +214,7 @@ M.debugprint_regular = function(opts)
 end
 
 ---@param opts? DebugprintFunctionOptions
+---@return string | nil
 M.debugprint = function(opts)
     local func_opts =
         require("debugprint.options").get_and_validate_function_opts(opts)

--- a/lua/debugprint/options.lua
+++ b/lua/debugprint/options.lua
@@ -162,7 +162,7 @@ M.get_and_validate_global_opts = function(opts)
     return global_opts
 end
 
----@param opts DebugprintFunctionOptions
+---@param opts? DebugprintFunctionOptions
 ---@return DebugprintFunctionOptions
 M.get_and_validate_function_opts = function(opts)
     local func_opts = vim.tbl_deep_extend(

--- a/lua/debugprint/setup.lua
+++ b/lua/debugprint/setup.lua
@@ -25,6 +25,7 @@ end
 M.map_keys_and_commands = function(global_opts)
     map_key("n", global_opts.keymaps.normal.plain_below, {
         callback = function()
+            ---@diagnostic disable-next-line: missing-fields
             feedkeys(debugprint.debugprint({}))
         end,
         desc = "Plain debug below current line",

--- a/lua/debugprint/setup.lua
+++ b/lua/debugprint/setup.lua
@@ -32,6 +32,7 @@ M.map_keys_and_commands = function(global_opts)
 
     map_key("n", global_opts.keymaps.normal.plain_above, {
         callback = function()
+            ---@diagnostic disable-next-line: missing-fields
             feedkeys(debugprint.debugprint({ above = true }))
         end,
         desc = "Plain debug above current line",
@@ -39,6 +40,7 @@ M.map_keys_and_commands = function(global_opts)
 
     map_key("n", global_opts.keymaps.normal.variable_below, {
         callback = function()
+            ---@diagnostic disable-next-line: missing-fields
             feedkeys(debugprint.debugprint({ variable = true }))
         end,
         desc = "Variable debug below current line",
@@ -46,6 +48,7 @@ M.map_keys_and_commands = function(global_opts)
 
     map_key("n", global_opts.keymaps.normal.variable_above, {
         callback = function()
+            ---@diagnostic disable-next-line: missing-fields
             feedkeys(debugprint.debugprint({
                 above = true,
                 variable = true,
@@ -56,6 +59,7 @@ M.map_keys_and_commands = function(global_opts)
 
     map_key("n", global_opts.keymaps.normal.variable_below_alwaysprompt, {
         callback = function()
+            ---@diagnostic disable-next-line: missing-fields
             feedkeys(debugprint.debugprint({
                 variable = true,
                 ignore_treesitter = true,
@@ -66,6 +70,7 @@ M.map_keys_and_commands = function(global_opts)
 
     map_key("n", global_opts.keymaps.normal.variable_above_alwaysprompt, {
         callback = function()
+            ---@diagnostic disable-next-line: missing-fields
             feedkeys(debugprint.debugprint({
                 above = true,
                 variable = true,
@@ -77,6 +82,7 @@ M.map_keys_and_commands = function(global_opts)
 
     map_key("n", global_opts.keymaps.normal.textobj_below, {
         callback = function()
+            ---@diagnostic disable-next-line: missing-fields
             return debugprint.debugprint({ motion = true })
         end,
         expr = true,
@@ -85,6 +91,7 @@ M.map_keys_and_commands = function(global_opts)
 
     map_key("n", global_opts.keymaps.normal.textobj_above, {
         callback = function()
+            ---@diagnostic disable-next-line: missing-fields
             return debugprint.debugprint({
                 motion = true,
                 above = true,
@@ -96,6 +103,7 @@ M.map_keys_and_commands = function(global_opts)
 
     map_key("x", global_opts.keymaps.visual.variable_below, {
         callback = function()
+            ---@diagnostic disable-next-line: missing-fields
             feedkeys(debugprint.debugprint({ variable = true }))
         end,
         desc = "Variable debug below current line",
@@ -103,6 +111,7 @@ M.map_keys_and_commands = function(global_opts)
 
     map_key("x", global_opts.keymaps.visual.variable_above, {
         callback = function()
+            ---@diagnostic disable-next-line: missing-fields
             feedkeys(debugprint.debugprint({
                 above = true,
                 variable = true,

--- a/lua/debugprint/types.lua
+++ b/lua/debugprint/types.lua
@@ -11,7 +11,7 @@
 
 ---@class DebugprintGlobalOptions
 ---@field keymaps? DebugprintKeymapOptions
----@field commands? table
+---@field commands? DebugprintCommandOptions
 ---@field display_counter? boolean
 ---@field display_location? boolean
 ---@field display_snippet? boolean
@@ -42,6 +42,10 @@
 ---@class DebugprintKeymapVisualOptions
 ---@field variable_below? string
 ---@field variable_above? string
+
+---@class DebugprintCommandOptions
+---@field delete_debug_prints? string
+---@field toggle_comment_debug_prints? string
 
 ---@class DebugprintFunctionOptions
 ---@field above boolean

--- a/lua/debugprint/types.lua
+++ b/lua/debugprint/types.lua
@@ -10,7 +10,7 @@
 ---@field find_treesitter_variable? function
 
 ---@class DebugprintGlobalOptions
----@field keymaps? table
+---@field keymaps? DebugprintKeymapOptions
 ---@field commands? table
 ---@field display_counter? boolean
 ---@field display_location? boolean
@@ -22,6 +22,26 @@
 ---@field create_keymaps? boolean
 ---@field create_commands? boolean
 ---@field ignore_treesitter? boolean
+
+---@class DebugprintKeymapOptions
+---@field normal DebugprintKeymapNormalOptions
+---@field visual DebugprintKeymapVisualOptions
+
+---@class DebugprintKeymapNormalOptions
+---@field plain_below? string
+---@field plain_above? string
+---@field variable_below? string
+---@field variable_above? string
+---@field variable_below_alwaysprompt? string
+---@field variable_above_alwaysprompt? string
+---@field textobj_below? string
+---@field textobj_above? string
+---@field delete_debug_prints? string
+---@field toggle_comment_debug_prints? string
+
+---@class DebugprintKeymapVisualOptions
+---@field variable_below? string
+---@field variable_above? string
 
 ---@class DebugprintFunctionOptions
 ---@field above boolean

--- a/tests/debugprint.lua
+++ b/tests/debugprint.lua
@@ -170,7 +170,12 @@ end)
 
 describe("can do basic debug statement insertion (custom keys)", function()
     before_each(function()
-        debugprint.setup({ keymaps = { normal = { plain_below = "zdp" } } })
+        debugprint.setup({
+            ---@diagnostic disable-next-line: missing-fields
+            keymaps = {
+                normal = { plain_below = "zdp" },
+            },
+        })
     end)
 
     after_each(teardown)
@@ -971,7 +976,10 @@ describe("can handle treesitter identifiers", function()
 
     it("always prompt below", function()
         debugprint.setup({
-            keymaps = { normal = { variable_below_alwaysprompt = "zxa" } },
+            ---@diagnostic disable-next-line: missing-fields
+            keymaps = {
+                normal = { variable_below_alwaysprompt = "zxa" },
+            },
         })
 
         local filename = init_file({
@@ -996,6 +1004,7 @@ describe("can handle treesitter identifiers", function()
 
     it("always prompt above", function()
         debugprint.setup({
+            ---@diagnostic disable-next-line: missing-fields
             keymaps = { normal = { variable_above_alwaysprompt = "zxb" } },
         })
 
@@ -1599,6 +1608,7 @@ describe("delete lines command", function()
 
     it("basic - with key binding", function()
         debugprint.setup({
+            ---@diagnostic disable-next-line: missing-fields
             keymaps = { normal = { delete_debug_prints = "g?x" } },
         })
 
@@ -1914,6 +1924,7 @@ describe("comment toggle", function()
 
     it("basic with keymaps", function()
         debugprint.setup({
+            ---@diagnostic disable-next-line: missing-fields
             keymaps = { normal = { toggle_comment_debug_prints = "g?x" } },
         })
         assert.equals(notify_message, nil)


### PR DESCRIPTION
Issue
=====

Currently the `DebugprintGlobalOptions` are typed as `table`, which makes it difficult to

- discover available keymaps using the lua_ls (lua LSP)
- verify that the code is coherent with the expected structure

Solution
========

Add types for all the supported keymaps into `types.lua`.