### PR TITLE
fix: validating nonexistent field `commands_toggle_comment_debug_prints`

### DIFF
--- a/lua/debugprint/options.lua
+++ b/lua/debugprint/options.lua
@@ -83,7 +83,7 @@ local validate_global_opts = function(o)
         textobj_above = { normal.textobj_above, STRING_NIL },
         delete_debug_prints = { normal.delete_debug_prints, STRING_NIL },
         commands_toggle_comment_debug_prints = {
-            normal.commands_toggle_comment_debug_prints,
+            normal.toggle_comment_debug_prints,
             STRING_NIL,
         },
     })


### PR DESCRIPTION
I think it was supposed to check if `normal.toggle_comment_debug_prints` has the correct type, but I think due to a typo is was checking a field that doesn't exist.