### PR TITLE
refactor: remove invalid phony targets from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all clean test
+.PHONY: test
 
 test:
 	nvim --headless --clean -u tests/minimal.vim -c "PlenaryBustedFile tests/debugprint.lua"


### PR DESCRIPTION
I started to implement a proof-of-concept for #107 and came across these. As far as I can tell they are not needed, so it might make sense to remove them.