### PR TITLE
Allow empty strings to disable mapping

### DIFF
--- a/lua/debugprint/setup.lua
+++ b/lua/debugprint/setup.lua
@@ -7,7 +7,7 @@ local debugprint = require("debugprint")
 ---@param opts table
 ---@return nil
 local map_key = function(mode, lhs, opts)
-    if lhs ~= nil then
+    if lhs ~= nil and lhs ~= '' then
         vim.api.nvim_set_keymap(mode, lhs, "", opts)
     end
 end


### PR DESCRIPTION
I noticed that if I set a mapping as nil, the default mappings would still be loaded into my config because of the vim.tbl_deep_copy function overwriting explicitly set nil values.

The easiest way to make it work for me is to ignore settings when the mapping is explicitly set as an empty string, as it's done in other plugins. It's working for my config, and hopefully this would be useful upstream.