### PR TITLE
docs: Swap out mini.nvim with mini.hipatterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ return {
     -- opts = { … },
 
     dependencies = {
-        "echasnovski/mini.nvim",        -- Optional: Needed for line highlighting
+        "echasnovski/mini.hipatterns",        -- Optional: Needed for line highlighting
         "ibhagwan/fzf-lua",             -- Optional: If you want to use the :SearchDebugPrints command with fzf-lua
         "nvim-telescope/telescope.nvim" -- Optional: If you want to use the :SearchDebugPrints command with telescope.nvim
     },


### PR DESCRIPTION
Swap out the mini.nvim optional dependency with mini.hipatterns, which is what the plugin uses. 
 