### PR TITLE
Update plugin references in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,9 +86,9 @@ return {
     -- opts = { … },
 
     dependencies = {
-        "echasnovski/mini.nvim",         -- Optional: Needed for line highlighting (full mini.nvim plugin)
+        "nvim-mini/mini.nvim",         -- Optional: Needed for line highlighting (full mini.nvim plugin)
                                          -- ... or ...
-        "echasnovski/mini.hipatterns",   -- Optional: Needed for line highlighting ('fine-grained' hipatterns plugin)
+        "nvim-mini/mini.hipatterns",   -- Optional: Needed for line highlighting ('fine-grained' hipatterns plugin)
 
         "ibhagwan/fzf-lua",              -- Optional: If you want to use the `:Debugprint search` command with fzf-lua
         "nvim-telescope/telescope.nvim", -- Optional: If you want to use the `:Debugprint search` command with telescope.nvim


### PR DESCRIPTION
The repos changed their name, just a small adjustment:

- https://github.com/nvim-mini/mini.hipatterns
- https://github.com/nvim-mini/mini.nvim